### PR TITLE
builds: correct issue preventing windows builds

### DIFF
--- a/depends/packages/openssl.mk
+++ b/depends/packages/openssl.mk
@@ -56,7 +56,8 @@ $(package)_config_opts_i686_mingw32=mingw
 endef
 
 define $(package)_preprocess_cmds
-  sed -i.old "s/define DATE .*/define DATE \"\"/g" util/mkbuildinf.pl
+  sed -i.old "s/define DATE .*/define DATE \"\"/g" util/mkbuildinf.pl && \
+  sed -i.old "s|\"engines\", \"apps\", \"test\"|\"engines\"|" Configure
 endef
 
 define $(package)_config_cmds


### PR DESCRIPTION
Corrects an issue preventing openssl from building for x86_64-w64-mingw32.