### PR TITLE
consensus: proceed with only 28.x clients

### DIFF
--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -160,9 +160,6 @@ struct Params {
     bool fStrictChainId;
     int nLegacyBlocksBefore; // -1 for "always allow"
 
-    /** Node parameters */
-    int nDropLegacyHeight;
-
     /**
      * Check whether or not minimum difficulty blocks are allowed
      * with the given time stamp.

--- a/src/kernel/chainparams.cpp
+++ b/src/kernel/chainparams.cpp
@@ -210,6 +210,7 @@ public:
                 {  2925000, uint256{"6a1f826799ec6763a7a17c246c1d175ec2beab5733453b466943d4c98fdab40f"}},
                 {  3000000, uint256{"a01b0ce4f7d5dfd34eb77652f50dab55c5e6cee63f7c422366a8f893129be650"}},
                 {  3075000, uint256{"fdcab8b4d081316ae8e698d4c955625ef573390a145f54b6f4a3066d2ad70239"}},
+                {  3150000, uint256("cd2ecbac21e33d8f925f266603f7927cd897d5a1398498364e1620de0d6cbaf5"}},
             }
         };
 

--- a/src/kernel/chainparams.cpp
+++ b/src/kernel/chainparams.cpp
@@ -122,10 +122,8 @@ public:
         consensus.nMinimumChainWork = uint256{"0000000000000000000000000000000000000000000000002f03094770f3d455"};  //block 3100000
         consensus.defaultAssumeValid = uint256{"633d6ddcddb33dfd8392a3650e04c2c3e353be575fe923615476ad603055e147"}; //block 3100000
 
-        consensus.nDropLegacyHeight = 3145555;
-
         consensus.nAuxpowChainId = 0x029c;
-        consensus.nAuxpowStartHeight = consensus.nDropLegacyHeight;
+        consensus.nAuxpowStartHeight = 3145555;
         consensus.nLegacyBlocksBefore = -1;
         consensus.fStrictChainId = true;
 
@@ -278,10 +276,8 @@ public:
         consensus.nMinimumChainWork = uint256{"0000000000000000000000000000000000000000000000000000000000000000"};
         consensus.defaultAssumeValid = uint256{"0000000000000000000000000000000000000000000000000000000000000000"};
 
-        consensus.nDropLegacyHeight = std::numeric_limits<int>::max();
-
         consensus.nAuxpowChainId = 0x029d;
-        consensus.nAuxpowStartHeight = consensus.nDropLegacyHeight;
+        consensus.nAuxpowStartHeight = std::numeric_limits<int>::max();
         consensus.nLegacyBlocksBefore = -1;
         consensus.fStrictChainId = true;
 

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -3766,13 +3766,6 @@ void PeerManagerImpl::ProcessMessage(CNode& pfrom, const std::string& msg_type, 
             return;
         }
 
-        if (nVersion < PROTOCOL_VERSION && GetBestBlock() >= m_chainparams.GetConsensus().nDropLegacyHeight) {
-            // disconnect from legacy hosts once a blockheight has been met
-            LogPrint(BCLog::NET, "peer=%d using legacy version %i; disconnecting\n", pfrom.GetId(), nVersion);
-            pfrom.fDisconnect = true;
-            return;
-        }
-
         if (!vRecv.empty()) {
             // The version message includes information about the sending node which we don't use:
             //   - 8 bytes (service bits)

--- a/src/node/protocol_version.h
+++ b/src/node/protocol_version.h
@@ -15,7 +15,7 @@ static const int PROTOCOL_VERSION = 70050;
 static const int INIT_PROTO_VERSION = 209;
 
 //! disconnect from peers older than this proto version
-static const int MIN_PEER_PROTO_VERSION = 70048;
+static const int MIN_PEER_PROTO_VERSION = PROTOCOL_VERSION;
 
 //! Version when we switched to a size-based "headers" limit.
 static const int SIZE_HEADERS_LIMIT_VERSION = PROTOCOL_VERSION;


### PR DESCRIPTION
Remove compatibility with older client, add a new checkpoint past fork height.