### PR TITLE
speed up initial sync

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2784,6 +2784,8 @@ bool PeerManagerImpl::CheckHeadersAreContinuous(const std::vector<CBlockHeader>&
 
 bool PeerManagerImpl::IsContinuationOfLowWorkHeadersSync(Peer& peer, CNode& pfrom, std::vector<CBlockHeader>& headers)
 {
+    return true;
+
     if (peer.m_headers_sync) {
         auto result = peer.m_headers_sync->ProcessNextHeaders(headers, headers.size() == MAX_HEADERS_RESULTS);
         // If it is a valid continuation, we should treat the existing getheaders request as responded to.


### PR DESCRIPTION
avoid pre-syncing headers and just begin by syncing headers as normal