### PR TITLE
build: fix Apple Silicon compile and macOS OpenSSL docs

### DIFF
--- a/doc/build-osx.md
+++ b/doc/build-osx.md
@@ -48,7 +48,17 @@ See [dependencies.md](dependencies.md) for a complete overview.
 To install, run the following from your terminal:
 
 ``` bash
-brew install automake libtool boost pkg-config libevent
+brew install automake libtool boost pkg-config libevent openssl@3
+```
+
+On Apple Silicon systems (M-series), OpenSSL headers and libraries are usually
+installed under Homebrew's prefix and may need to be passed explicitly to
+`configure`:
+
+``` bash
+CPPFLAGS="-I$(brew --prefix openssl@3)/include" \
+LDFLAGS="-L$(brew --prefix openssl@3)/lib" \
+./configure --with-gui=no
 ```
 
 For macOS 11 (Big Sur) and 12 (Monterey) you need to install a more recent version of llvm.
@@ -196,6 +206,9 @@ Additionally, this explicitly disables the GUI.
 ./autogen.sh
 ./configure --with-gui=no
 ```
+
+If you encounter `libcrypto headers missing` on macOS, use the OpenSSL flags
+shown in the dependency section above.
 
 ##### Wallet (only SQlite) and GUI Support:
 

--- a/src/crypto/scrypt.cpp
+++ b/src/crypto/scrypt.cpp
@@ -34,14 +34,6 @@
 #include <stdint.h>
 #include <string.h>
 
-#ifdef _MSC_VER
-// MSVC 64bit is unable to use inline asm
-#include <intrin.h>
-#else
-// GCC Linux or i686-w64-mingw32
-#include <cpuid.h>
-#endif
-
 #ifndef __FreeBSD__
 static inline uint32_t be32dec(const void *pp)
 {


### PR DESCRIPTION
## Summary
- remove unused x86-only `cpuid.h`/`intrin.h` includes from `src/crypto/scrypt.cpp` so the code compiles on Apple Silicon (arm64)
- update `doc/build-osx.md` to include `openssl@3` in dependencies and document `CPPFLAGS`/`LDFLAGS` for Homebrew OpenSSL paths
- add a macOS troubleshooting note for `libcrypto headers missing`

## Validation
- built on macOS arm64 (Apple Silicon) with `./configure --without-gui --disable-tests --disable-bench` and `make -j$(sysctl -n hw.ncpu)`
- verified `marscoind` and `marscoin-cli` run correctly
- started from blockchain snapshot and confirmed node reached `initialblockdownload=false` with active peers
- loaded multiple backup wallets in a dedicated test datadir and confirmed wallet RPC reads