### PR TITLE
release: add 28.1.1 workflows and notes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,89 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - "**"
+    tags-ignore:
+      - "**"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  linux-cli-build:
+    name: Linux CLI Build
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            build-essential \
+            automake \
+            libtool \
+            autotools-dev \
+            pkg-config \
+            python3 \
+            libevent-dev \
+            libboost-dev \
+            libsqlite3-dev \
+            libssl-dev \
+            libminiupnpc-dev \
+            libnatpmp-dev
+
+      - name: Configure
+        run: |
+          ./autogen.sh
+          ./configure --without-gui --disable-tests --disable-bench
+
+      - name: Build
+        run: make -j"$(nproc)"
+
+      - name: Smoke check
+        run: |
+          ./src/marscoind --version
+          ./src/marscoin-cli --version
+
+  macos-arm64-gui-build:
+    name: macOS ARM64 GUI Build
+    runs-on: macos-14
+    timeout-minutes: 75
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          brew install automake libtool boost pkg-config libevent openssl@3 qt@5 miniupnpc
+
+      - name: Configure
+        run: |
+          PATH="$(brew --prefix qt@5)/bin:$PATH" \
+          CPPFLAGS="-I$(brew --prefix openssl@3)/include" \
+          LDFLAGS="-L$(brew --prefix openssl@3)/lib" \
+          ./autogen.sh
+          PATH="$(brew --prefix qt@5)/bin:$PATH" \
+          CPPFLAGS="-I$(brew --prefix openssl@3)/include" \
+          LDFLAGS="-L$(brew --prefix openssl@3)/lib" \
+          ./configure --with-gui=yes --disable-tests --disable-bench
+
+      - name: Build
+        run: |
+          make -j"$(sysctl -n hw.ncpu)" src/marscoind
+          make -j"$(sysctl -n hw.ncpu)" src/marscoin-cli
+          make -j"$(sysctl -n hw.ncpu)" src/qt/marscoin-qt
+
+      - name: Smoke check
+        run: |
+          ./src/qt/marscoin-qt -version
+          ./src/marscoind --version
+          ./src/marscoin-cli --version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,191 @@
+name: Release Binaries
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  build-linux-macos:
+    name: Build ${{ matrix.target }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-24.04
+            target: linux-x86_64
+            gui: "no"
+          - os: macos-13
+            target: macos-x86_64
+            gui: "yes"
+          - os: macos-14
+            target: macos-arm64
+            gui: "yes"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Linux dependencies
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            build-essential \
+            automake \
+            libtool \
+            autotools-dev \
+            pkg-config \
+            python3 \
+            libevent-dev \
+            libboost-dev \
+            libsqlite3-dev \
+            libssl-dev \
+            libminiupnpc-dev \
+            libnatpmp-dev
+
+      - name: Install macOS dependencies
+        if: runner.os == 'macOS'
+        run: |
+          brew install automake libtool boost pkg-config libevent openssl@3 qt@5 miniupnpc
+
+      - name: Configure
+        run: |
+          if [ "${{ runner.os }}" = "macOS" ]; then
+            PATH="$(brew --prefix qt@5)/bin:$PATH" \
+            CPPFLAGS="-I$(brew --prefix openssl@3)/include" \
+            LDFLAGS="-L$(brew --prefix openssl@3)/lib" \
+            ./autogen.sh
+            PATH="$(brew --prefix qt@5)/bin:$PATH" \
+            CPPFLAGS="-I$(brew --prefix openssl@3)/include" \
+            LDFLAGS="-L$(brew --prefix openssl@3)/lib" \
+            ./configure --with-gui=${{ matrix.gui }} --disable-tests --disable-bench
+          else
+            ./autogen.sh
+            ./configure --with-gui=${{ matrix.gui }} --disable-tests --disable-bench
+          fi
+
+      - name: Build
+        run: |
+          if [ "${{ runner.os }}" = "macOS" ]; then
+            make -j"$(sysctl -n hw.ncpu)" src/marscoind src/marscoin-cli src/marscoin-tx src/marscoin-util
+            make -j"$(sysctl -n hw.ncpu)" src/qt/marscoin-qt
+          else
+            make -j"$(nproc)" src/marscoind src/marscoin-cli src/marscoin-tx src/marscoin-util
+          fi
+
+      - name: Package artifacts
+        run: |
+          mkdir -p dist/bin
+          cp src/marscoind dist/bin/
+          cp src/marscoin-cli dist/bin/
+          cp src/marscoin-tx dist/bin/
+          cp src/marscoin-util dist/bin/
+          if [ "${{ matrix.gui }}" = "yes" ]; then
+            cp src/qt/marscoin-qt dist/bin/
+          fi
+          tar -czf "marscoin-${{ github.ref_name }}-${{ matrix.target }}.tar.gz" -C dist bin
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: marscoin-${{ github.ref_name }}-${{ matrix.target }}
+          path: marscoin-${{ github.ref_name }}-${{ matrix.target }}.tar.gz
+
+  build-windows:
+    name: Build windows-x86_64
+    runs-on: windows-2022
+    timeout-minutes: 90
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up MSYS2
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: MINGW64
+          update: true
+          install: >-
+            base-devel
+            mingw-w64-x86_64-toolchain
+            mingw-w64-x86_64-autotools
+            mingw-w64-x86_64-libevent
+            mingw-w64-x86_64-boost
+            mingw-w64-x86_64-openssl
+            mingw-w64-x86_64-miniupnpc
+            mingw-w64-x86_64-python
+
+      - name: Configure and build
+        shell: msys2 {0}
+        run: |
+          ./autogen.sh
+          ./configure --without-gui --disable-tests --disable-bench
+          make -j"$(nproc)" src/marscoind.exe src/marscoin-cli.exe src/marscoin-tx.exe src/marscoin-util.exe
+
+      - name: Package artifacts
+        shell: msys2 {0}
+        run: |
+          mkdir -p dist/bin
+          cp src/marscoind.exe dist/bin/
+          cp src/marscoin-cli.exe dist/bin/
+          cp src/marscoin-tx.exe dist/bin/
+          cp src/marscoin-util.exe dist/bin/
+          tar -czf "marscoin-${{ github.ref_name }}-windows-x86_64.tar.gz" -C dist bin
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: marscoin-${{ github.ref_name }}-windows-x86_64
+          path: marscoin-${{ github.ref_name }}-windows-x86_64.tar.gz
+
+  checksums:
+    name: Generate checksums
+    runs-on: ubuntu-24.04
+    needs:
+      - build-linux-macos
+      - build-windows
+
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: release-assets
+
+      - name: Generate SHA256SUMS
+        run: |
+          find release-assets -name "*.tar.gz" -type f -print0 | xargs -0 sha256sum > SHA256SUMS
+
+      - name: Upload checksums artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: marscoin-${{ github.ref_name }}-checksums
+          path: SHA256SUMS
+
+  publish:
+    name: Publish GitHub Release Assets
+    runs-on: ubuntu-24.04
+    needs:
+      - build-linux-macos
+      - build-windows
+      - checksums
+    if: startsWith(github.ref, 'refs/tags/v')
+
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: release-assets
+
+      - name: Attach assets to release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            release-assets/**/*.tar.gz
+            release-assets/**/SHA256SUMS

--- a/doc/release-notes/release-notes-28.1.1.md
+++ b/doc/release-notes/release-notes-28.1.1.md
@@ -1,0 +1,54 @@
+Marscoin Core version 28.1.1 is now available from:
+
+  <https://github.com/marscoin/marscoin/releases/tag/v28.1.1>
+
+This is a maintenance and build-portability release focused on improving
+cross-platform build reliability and release distribution.
+
+How to Upgrade
+==============
+
+If you are running an older version, shut it down cleanly and wait for it to
+fully exit before replacing binaries.
+
+- macOS: replace `marscoin-qt` or CLI binaries, then restart.
+- Linux: replace `marscoind`, `marscoin-cli`, `marscoin-tx`, `marscoin-util`.
+- Windows: replace `.exe` binaries and restart the node/wallet.
+
+Notable changes
+===============
+
+Apple Silicon build compatibility
+---------------------------------
+
+- Removed x86-only includes from `src/crypto/scrypt.cpp` that were not used by
+  the active implementation path. This fixes compilation on macOS arm64
+  toolchains.
+
+macOS build documentation update
+--------------------------------
+
+- Updated `doc/build-osx.md` to include `openssl@3` in dependencies.
+- Added Homebrew `CPPFLAGS`/`LDFLAGS` examples for OpenSSL header/library
+  discovery on modern macOS setups.
+
+CI and release automation
+-------------------------
+
+- Added GitHub Actions CI workflow for Linux CLI and macOS arm64 GUI builds.
+- Added tag-driven release workflow that builds and publishes release artifacts
+  for Linux x86_64, macOS x86_64, macOS arm64, and Windows x86_64.
+- Added generated `SHA256SUMS` publication in release assets.
+
+Verification notes
+------------------
+
+- macOS arm64 local validation included build, daemon startup, CLI RPC checks,
+  snapshot-assisted synchronization, and wallet loading tests.
+- GitHub-hosted CI validated Linux and macOS build pipeline execution.
+
+Credits
+=======
+
+Thanks to everyone testing Marscoin Core on modern hardware, especially macOS
+Intel and Apple Silicon users reporting compatibility and sync issues.


### PR DESCRIPTION
## Summary
- add `.github/workflows/ci.yml` with Linux CLI and macOS arm64 GUI build checks
- add `.github/workflows/release.yml` for tag-based release artifacts on Linux x86_64, macOS x86_64, macOS arm64, and Windows x86_64
- add `doc/release-notes/release-notes-28.1.1.md` with upgrade notes and the 28.1.1 change summary

## Why
- make releases reproducible and accessible to non-developer users across major desktop/server platforms
- avoid regressions in macOS ARM64 build compatibility
- provide a clear release-notes baseline for v28.1.1