### PR TITLE
release: fix Windows GUI linking in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -173,7 +173,7 @@ jobs:
           make -j"$(nproc)" src/marscoin-cli.exe
           make -j"$(nproc)" src/marscoin-tx.exe
           make -j"$(nproc)" src/marscoin-util.exe
-          make -j"$(nproc)" src/qt/marscoin-qt.exe
+          make V=1 -j"$(nproc)" src/qt/marscoin-qt.exe
 
       - name: Package artifacts
         shell: msys2 {0}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -169,11 +169,11 @@ jobs:
           fi
           ./autogen.sh
           LIBS="-lcrypt32" MOC="$MOC_BIN" UIC="$UIC_BIN" RCC="$RCC_BIN" LRELEASE="$LRELEASE_BIN" ./configure --with-gui=yes --disable-tests --disable-bench --disable-static
-          make -j"$(nproc)" src/marscoind.exe
-          make -j"$(nproc)" src/marscoin-cli.exe
-          make -j"$(nproc)" src/marscoin-tx.exe
-          make -j"$(nproc)" src/marscoin-util.exe
-          make V=1 -j"$(nproc)" src/qt/marscoin-qt.exe
+          make LIBTOOL_APP_LDFLAGS= -j"$(nproc)" src/marscoind.exe
+          make LIBTOOL_APP_LDFLAGS= -j"$(nproc)" src/marscoin-cli.exe
+          make LIBTOOL_APP_LDFLAGS= -j"$(nproc)" src/marscoin-tx.exe
+          make LIBTOOL_APP_LDFLAGS= -j"$(nproc)" src/marscoin-util.exe
+          make V=1 LIBTOOL_APP_LDFLAGS= -j"$(nproc)" src/qt/marscoin-qt.exe
 
       - name: Package artifacts
         shell: msys2 {0}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,7 +102,7 @@ jobs:
       - name: Upload build artifact
         uses: actions/upload-artifact@v4
         with:
-          name: marscoin-${{ github.ref_name }}-${{ matrix.target }}
+          name: marscoin-${{ matrix.target }}-${{ github.run_id }}
           path: marscoin-*-${{ matrix.target }}.tar.gz
 
   build-windows:
@@ -168,7 +168,7 @@ jobs:
             LRELEASE_BIN="/mingw64/bin/lrelease.exe"
           fi
           ./autogen.sh
-          LIBS="-lcrypt32" MOC="$MOC_BIN" UIC="$UIC_BIN" RCC="$RCC_BIN" LRELEASE="$LRELEASE_BIN" ./configure --with-gui=yes --disable-tests --disable-bench
+          LIBS="-lcrypt32" MOC="$MOC_BIN" UIC="$UIC_BIN" RCC="$RCC_BIN" LRELEASE="$LRELEASE_BIN" ./configure --with-gui=yes --disable-tests --disable-bench --disable-static
           make -j"$(nproc)" src/marscoind.exe
           make -j"$(nproc)" src/marscoin-cli.exe
           make -j"$(nproc)" src/marscoin-tx.exe
@@ -190,7 +190,7 @@ jobs:
       - name: Upload build artifact
         uses: actions/upload-artifact@v4
         with:
-          name: marscoin-${{ github.ref_name }}-windows-x86_64
+          name: marscoin-windows-x86_64-${{ github.run_id }}
           path: marscoin-*-windows-x86_64.tar.gz
 
   checksums:
@@ -213,7 +213,7 @@ jobs:
       - name: Upload checksums artifact
         uses: actions/upload-artifact@v4
         with:
-          name: marscoin-${{ github.ref_name }}-checksums
+          name: marscoin-checksums-${{ github.run_id }}
           path: SHA256SUMS
 
   publish:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,6 +136,9 @@ jobs:
         shell: msys2 {0}
         run: |
           export PATH="/mingw64/qt5/bin:/mingw64/lib/qt5/bin:/mingw64/bin:$PATH"
+          export PKG_CONFIG_PATH="/mingw64/lib/pkgconfig:/mingw64/share/pkgconfig"
+          export CPPFLAGS="-I/mingw64/include"
+          export LDFLAGS="-L/mingw64/lib -L/mingw64/qt5/lib -L/mingw64/lib/qt5/lib"
           MOC_BIN="$(command -v moc-qt5 || command -v moc || true)"
           if [ -z "$MOC_BIN" ] && [ -x /mingw64/qt5/bin/moc.exe ]; then
             MOC_BIN="/mingw64/qt5/bin/moc.exe"
@@ -166,11 +169,11 @@ jobs:
           fi
           ./autogen.sh
           LIBS="-lcrypt32" MOC="$MOC_BIN" UIC="$UIC_BIN" RCC="$RCC_BIN" LRELEASE="$LRELEASE_BIN" ./configure --with-gui=yes --disable-tests --disable-bench
-          LIBS="-lcrypt32" make -j"$(nproc)" src/marscoind.exe
-          LIBS="-lcrypt32" make -j"$(nproc)" src/marscoin-cli.exe
-          LIBS="-lcrypt32" make -j"$(nproc)" src/marscoin-tx.exe
-          LIBS="-lcrypt32" make -j"$(nproc)" src/marscoin-util.exe
-          LIBS="-lcrypt32" make -j"$(nproc)" src/qt/marscoin-qt.exe
+          make -j"$(nproc)" src/marscoind.exe
+          make -j"$(nproc)" src/marscoin-cli.exe
+          make -j"$(nproc)" src/marscoin-tx.exe
+          make -j"$(nproc)" src/marscoin-util.exe
+          make -j"$(nproc)" src/qt/marscoin-qt.exe
 
       - name: Package artifacts
         shell: msys2 {0}


### PR DESCRIPTION
## Summary
- fix Windows GUI linking in release workflow by overriding `LIBTOOL_APP_LDFLAGS` during Windows builds to avoid forced `-all-static` Qt link mode
- keep Windows, Linux, macOS Intel, and macOS ARM artifact generation in one passing matrix
- retain artifact naming sanitization and checksum generation introduced for branch/test safety

## Validation
- successful full workflow run on this branch: https://github.com/marscoin/marscoin/actions/runs/24296806102
- passed jobs:
  - Build windows-x86_64
  - Build linux-x86_64
  - Build macos-x86_64
  - Build macos-arm64
  - Generate checksums