### PR TITLE
quantum: scaffold post-quantum address format hooks

### DIFF
--- a/doc/quantum-address-format-v1.md
+++ b/doc/quantum-address-format-v1.md
@@ -1,0 +1,54 @@
+# Post-Quantum Address Format v1 (Scaffold)
+
+This document defines the initial scaffold for Marscoin post-quantum addresses.
+It is intentionally non-consensus and non-activating in this branch.
+
+## Goals
+
+- Reserve a recognizable user-facing prefix for post-quantum recipients.
+- Add parser detection hooks so wallet/RPC can return actionable errors.
+- Prepare for a follow-up consensus proposal without disrupting existing address types.
+
+## Reserved Prefix
+
+- Mainnet: `mars1pq...`
+- Testnet: `tmars1pq...`
+- Signet: `tb1pq...`
+- Regtest: `bcrt1pq...`
+
+The reserved prefix is defined as:
+
+`<bech32_hrp> + "1pq"`
+
+Detection in this scaffold is case-insensitive and prefix-only. Payload format,
+checksum details, and script mapping are deferred to the full specification.
+
+## Current Behavior (Scaffold Branch)
+
+- `DecodeDestination()` recognizes the reserved prefix.
+- Decoding does not produce a spendable destination yet.
+- The API returns `CNoDestination` with a deterministic error string:
+
+`Post-quantum address format is recognized but not enabled yet`
+
+## Test Vectors (Prefix Detection Only)
+
+### Expected `IsPostQuantumAddress(...) == true`
+
+- `mars1pqexampleaddress0000000000000000000000`
+- `tmars1pqexampleaddress000000000000000000000`
+- `tb1pqexampleaddress000000000000000000000000`
+- `bcrt1pqexampleaddress0000000000000000000000`
+
+### Expected `IsPostQuantumAddress(...) == false`
+
+- `mars1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh`
+- `M4f82c4d228f34c5bde0f6968dcfdbf67e`
+- `bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kg3g4ty`
+
+## Next Steps
+
+1. Specify payload encoding and checksum scheme.
+2. Define scriptPubKey mapping and destination type.
+3. Add full round-trip vectors (`encode -> decode -> script`).
+4. Gate activation logic behind explicit consensus deployment parameters.

--- a/src/key_io.cpp
+++ b/src/key_io.cpp
@@ -87,6 +87,11 @@ CTxDestination DecodeDestination(const std::string& str, const CChainParams& par
     uint160 hash;
     error_str = "";
 
+    if (IsPostQuantumAddress(str, params)) {
+        error_str = "Post-quantum address format is recognized but not enabled yet";
+        return CNoDestination();
+    }
+
     // Note this will be false if it is a valid Bech32 address for a different network
     bool is_bech32 = (ToLower(str.substr(0, params.Bech32HRP().size())) == params.Bech32HRP());
 
@@ -316,4 +321,15 @@ bool IsValidDestinationString(const std::string& str, const CChainParams& params
 bool IsValidDestinationString(const std::string& str)
 {
     return IsValidDestinationString(str, Params());
+}
+
+bool IsPostQuantumAddress(const std::string& str, const CChainParams& params)
+{
+    const std::string pq_prefix{params.Bech32HRP() + "1pq"};
+    return ToLower(str).rfind(pq_prefix, 0) == 0;
+}
+
+bool IsPostQuantumAddress(const std::string& str)
+{
+    return IsPostQuantumAddress(str, Params());
 }

--- a/src/key_io.h
+++ b/src/key_io.h
@@ -27,4 +27,7 @@ CTxDestination DecodeDestination(const std::string& str, std::string& error_msg,
 bool IsValidDestinationString(const std::string& str);
 bool IsValidDestinationString(const std::string& str, const CChainParams& params);
 
+bool IsPostQuantumAddress(const std::string& str);
+bool IsPostQuantumAddress(const std::string& str, const CChainParams& params);
+
 #endif // BITCOIN_KEY_IO_H

--- a/src/test/data/pq_address_prefix_vectors.json
+++ b/src/test/data/pq_address_prefix_vectors.json
@@ -1,0 +1,42 @@
+[
+  {
+    "address": "mars1pqexampleaddress0000000000000000000000",
+    "chain": "main",
+    "is_pq_prefix": true,
+    "roundtrip_supported": false,
+    "expected_error": "Post-quantum address format is recognized but not enabled yet"
+  },
+  {
+    "address": "tmars1pqexampleaddress000000000000000000000",
+    "chain": "test",
+    "is_pq_prefix": true,
+    "roundtrip_supported": false,
+    "expected_error": "Post-quantum address format is recognized but not enabled yet"
+  },
+  {
+    "address": "tb1pqexampleaddress000000000000000000000000",
+    "chain": "signet",
+    "is_pq_prefix": true,
+    "roundtrip_supported": false,
+    "expected_error": "Post-quantum address format is recognized but not enabled yet"
+  },
+  {
+    "address": "bcrt1pqexampleaddress0000000000000000000000",
+    "chain": "regtest",
+    "is_pq_prefix": true,
+    "roundtrip_supported": false,
+    "expected_error": "Post-quantum address format is recognized but not enabled yet"
+  },
+  {
+    "address": "mars1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh",
+    "chain": "main",
+    "is_pq_prefix": false,
+    "roundtrip_supported": true
+  },
+  {
+    "address": "M4f82c4d228f34c5bde0f6968dcfdbf67e",
+    "chain": "main",
+    "is_pq_prefix": false,
+    "roundtrip_supported": true
+  }
+]

--- a/src/test/key_io_tests.cpp
+++ b/src/test/key_io_tests.cpp
@@ -146,4 +146,38 @@ BOOST_AUTO_TEST_CASE(key_io_invalid)
     }
 }
 
+BOOST_AUTO_TEST_CASE(key_io_post_quantum_address_scaffold)
+{
+    struct PrefixVector {
+        ChainType chain;
+        std::string address;
+        bool is_pq;
+    };
+
+    const std::vector<PrefixVector> vectors{
+        {ChainType::MAIN, "mars1pqexampleaddress0000000000000000000000", true},
+        {ChainType::TESTNET, "tmars1pqexampleaddress000000000000000000000", true},
+        {ChainType::SIGNET, "tb1pqexampleaddress000000000000000000000000", true},
+        {ChainType::REGTEST, "bcrt1pqexampleaddress0000000000000000000000", true},
+        {ChainType::MAIN, "mars1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh", false},
+        {ChainType::MAIN, "M4f82c4d228f34c5bde0f6968dcfdbf67e", false},
+    };
+
+    for (const auto& vector : vectors) {
+        SelectParams(vector.chain);
+        BOOST_CHECK_EQUAL(IsPostQuantumAddress(vector.address), vector.is_pq);
+    }
+
+    SelectParams(ChainType::MAIN);
+    std::string error;
+    const CTxDestination dest = DecodeDestination("mars1pqexampleaddress0000000000000000000000", error);
+    BOOST_CHECK(!IsValidDestination(dest));
+    BOOST_CHECK_EQUAL(error, "Post-quantum address format is recognized but not enabled yet");
+
+    // This is the error text surfaced by RPC endpoints like getaddressinfo.
+    std::string rpc_error;
+    (void)DecodeDestination("mars1pqdeadbeefdeadbeefdeadbeefdeadbeef", rpc_error);
+    BOOST_CHECK_EQUAL(rpc_error, "Post-quantum address format is recognized but not enabled yet");
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Summary
- add `IsPostQuantumAddress(...)` helpers in `src/key_io` with reserved prefix detection (`<bech32_hrp> + 1pq`)
- add non-activating decode behavior that recognizes PQ-prefixed addresses and returns a deterministic error
- add scaffold tests in `src/test/key_io_tests.cpp` for prefix vectors and RPC-facing error propagation behavior
- add scaffold docs and machine-readable vectors:
  - `doc/quantum-address-format-v1.md`
  - `src/test/data/pq_address_prefix_vectors.json`

## Scope
This PR is scaffold-only and does **not** activate consensus behavior or introduce a spendable PQ destination type.

## Validation
- local build passes for `marscoind` and `marscoin-cli`
- deterministic decode error string verified in unit test additions

Closes #35