### PR TITLE
quantum: scaffold SPHINCS+ signature parsing types and tests

### DIFF
--- a/doc/quantum-signatures-sphincs-v1.md
+++ b/doc/quantum-signatures-sphincs-v1.md
@@ -1,0 +1,56 @@
+# SPHINCS+ Signature Scaffold v1
+
+This document defines the first non-activating scaffold for SPHINCS+
+signature handling in Marscoin Core.
+
+## Purpose
+
+- Add explicit types and parser validation hooks for SPHINCS+ payloads.
+- Keep consensus behavior unchanged while implementation work is staged.
+- Provide stable test vectors and deterministic error outputs.
+
+## Scaffold Payload Format
+
+For test-only parsing, the payload format is:
+
+`[1-byte parameter set id][raw signature bytes]`
+
+Currently recognized parameter set id:
+
+- `0x00`: `SLH-DSA-SHA2-128s`
+
+Current size constants for this scaffold:
+
+- Public key bytes: `32`
+- Secret key bytes: `64`
+- Signature bytes: `7856`
+
+## Current Validation Semantics
+
+Validation currently checks only:
+
+1. payload is non-empty,
+2. parameter set id is supported,
+3. payload length matches expected size for that parameter set.
+
+No cryptographic verification is performed in this scaffold.
+
+Deterministic error strings:
+
+- `Empty SPHINCS+ payload`
+- `Unsupported SPHINCS+ parameter set`
+- `Invalid SPHINCS+ payload length`
+
+## Explicit Non-Goals (v1 Scaffold)
+
+- No transaction/script activation
+- No OP code or witness program changes
+- No wallet signing path
+- No mempool/consensus acceptance changes
+
+## Follow-up Work
+
+1. Bind parsed payloads to new signature destination/script types.
+2. Integrate concrete SPHINCS+ implementation and key management.
+3. Add deterministic vector-based sign/verify tests.
+4. Gate consensus activation behind deployment parameters.

--- a/src/crypto/pq_sphincs.h
+++ b/src/crypto/pq_sphincs.h
@@ -1,0 +1,75 @@
+// Copyright (c) 2026 The Marscoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_CRYPTO_PQ_SPHINCS_H
+#define BITCOIN_CRYPTO_PQ_SPHINCS_H
+
+#include <span.h>
+
+#include <cstdint>
+#include <string>
+
+namespace pq::sphincs {
+
+enum class ParameterSet : uint8_t {
+    SLH_DSA_SHA2_128S = 0x00,
+};
+
+static constexpr size_t SPHINCS_SIGNATURE_SIZE_SHA2_128S = 7856;
+static constexpr size_t SPHINCS_PUBLIC_KEY_SIZE_SHA2_128S = 32;
+static constexpr size_t SPHINCS_SECRET_KEY_SIZE_SHA2_128S = 64;
+
+inline constexpr bool IsSupportedParameterSet(const uint8_t value)
+{
+    return value == static_cast<uint8_t>(ParameterSet::SLH_DSA_SHA2_128S);
+}
+
+inline constexpr size_t SignatureSize(const ParameterSet parameter_set)
+{
+    switch (parameter_set) {
+    case ParameterSet::SLH_DSA_SHA2_128S:
+        return SPHINCS_SIGNATURE_SIZE_SHA2_128S;
+    }
+    return 0;
+}
+
+inline const char* ParameterSetName(const ParameterSet parameter_set)
+{
+    switch (parameter_set) {
+    case ParameterSet::SLH_DSA_SHA2_128S:
+        return "SLH-DSA-SHA2-128s";
+    }
+    return "unknown";
+}
+
+/**
+ * Validate scaffold SPHINCS+ payload encoding.
+ *
+ * This checks only length/format and does not perform cryptographic verify.
+ * Expected scaffold payload format:
+ *   [0]: parameter set id
+ *   [1..n]: raw signature bytes for the selected parameter set
+ */
+inline std::string ValidateSignatureEncoding(const Span<const unsigned char> payload)
+{
+    if (payload.empty()) {
+        return "Empty SPHINCS+ payload";
+    }
+
+    const uint8_t parameter_set{payload.front()};
+    if (!IsSupportedParameterSet(parameter_set)) {
+        return "Unsupported SPHINCS+ parameter set";
+    }
+
+    const auto expected_size = SignatureSize(static_cast<ParameterSet>(parameter_set));
+    if (payload.size() != expected_size + 1) {
+        return "Invalid SPHINCS+ payload length";
+    }
+
+    return {};
+}
+
+} // namespace pq::sphincs
+
+#endif // BITCOIN_CRYPTO_PQ_SPHINCS_H

--- a/src/test/crypto_tests.cpp
+++ b/src/test/crypto_tests.cpp
@@ -9,6 +9,7 @@
 #include <crypto/hmac_sha256.h>
 #include <crypto/hmac_sha512.h>
 #include <crypto/poly1305.h>
+#include <crypto/pq_sphincs.h>
 #include <crypto/ripemd160.h>
 #include <crypto/sha1.h>
 #include <crypto/sha256.h>
@@ -1268,6 +1269,30 @@ BOOST_AUTO_TEST_CASE(muhash_tests)
     uint256 out4;
     overflowchk.Finalize(out4);
     BOOST_CHECK_EQUAL(HexStr(out4), "3a31e6903aff0de9f62f9a9f7f8b861de76ce2cda09822b90014319ae5dc2271");
+}
+
+BOOST_AUTO_TEST_CASE(pq_sphincs_signature_scaffold)
+{
+    using pq::sphincs::ParameterSet;
+    using pq::sphincs::SPHINCS_SIGNATURE_SIZE_SHA2_128S;
+
+    BOOST_CHECK(pq::sphincs::IsSupportedParameterSet(static_cast<uint8_t>(ParameterSet::SLH_DSA_SHA2_128S)));
+    BOOST_CHECK_EQUAL(pq::sphincs::ParameterSetName(ParameterSet::SLH_DSA_SHA2_128S), "SLH-DSA-SHA2-128s");
+
+    std::vector<unsigned char> payload_valid(1 + SPHINCS_SIGNATURE_SIZE_SHA2_128S, 0x00);
+    payload_valid[0] = static_cast<uint8_t>(ParameterSet::SLH_DSA_SHA2_128S);
+    BOOST_CHECK(pq::sphincs::ValidateSignatureEncoding(payload_valid).empty());
+
+    const std::vector<unsigned char> payload_empty;
+    BOOST_CHECK_EQUAL(pq::sphincs::ValidateSignatureEncoding(payload_empty), "Empty SPHINCS+ payload");
+
+    std::vector<unsigned char> payload_bad_set(1 + SPHINCS_SIGNATURE_SIZE_SHA2_128S, 0x00);
+    payload_bad_set[0] = 0x7f;
+    BOOST_CHECK_EQUAL(pq::sphincs::ValidateSignatureEncoding(payload_bad_set), "Unsupported SPHINCS+ parameter set");
+
+    std::vector<unsigned char> payload_bad_len(SPHINCS_SIGNATURE_SIZE_SHA2_128S, 0x00);
+    payload_bad_len[0] = static_cast<uint8_t>(ParameterSet::SLH_DSA_SHA2_128S);
+    BOOST_CHECK_EQUAL(pq::sphincs::ValidateSignatureEncoding(payload_bad_len), "Invalid SPHINCS+ payload length");
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/data/pq_sphincs_scaffold_vectors.json
+++ b/src/test/data/pq_sphincs_scaffold_vectors.json
@@ -1,0 +1,28 @@
+[
+  {
+    "name": "valid_sha2_128s_minimal_zeroed",
+    "parameter_set": 0,
+    "payload_length": 7857,
+    "valid_encoding": true
+  },
+  {
+    "name": "empty_payload",
+    "payload_length": 0,
+    "valid_encoding": false,
+    "expected_error": "Empty SPHINCS+ payload"
+  },
+  {
+    "name": "unsupported_parameter_set",
+    "parameter_set": 127,
+    "payload_length": 7857,
+    "valid_encoding": false,
+    "expected_error": "Unsupported SPHINCS+ parameter set"
+  },
+  {
+    "name": "invalid_length",
+    "parameter_set": 0,
+    "payload_length": 7856,
+    "valid_encoding": false,
+    "expected_error": "Invalid SPHINCS+ payload length"
+  }
+]


### PR DESCRIPTION
## Summary
- add scaffold SPHINCS+ header `src/crypto/pq_sphincs.h` with:
  - parameter-set enum (`SLH-DSA-SHA2-128s`)
  - size constants
  - deterministic scaffold encoding validator
- add unit coverage in `src/test/crypto_tests.cpp` for:
  - supported parameter set recognition
  - valid scaffold payload acceptance
  - deterministic errors on empty/unsupported/invalid-length payloads
- add scaffold spec doc `doc/quantum-signatures-sphincs-v1.md`
- add machine-readable scaffold vectors `src/test/data/pq_sphincs_scaffold_vectors.json`

## Scope
This PR is scaffold-only and does not activate consensus behavior or cryptographic SPHINCS+ verification.

## Validation
- `make src/test/test_marscoin` in this environment reported no pending rebuild
- test logic added under existing `crypto_tests` suite

Closes #33