### PR TITLE
quantum: add getnewpqaddress RPC and PQ wallet key storage

### DIFF
--- a/src/outputtype.cpp
+++ b/src/outputtype.cpp
@@ -19,6 +19,7 @@ static const std::string OUTPUT_TYPE_STRING_LEGACY = "legacy";
 static const std::string OUTPUT_TYPE_STRING_P2SH_SEGWIT = "p2sh-segwit";
 static const std::string OUTPUT_TYPE_STRING_BECH32 = "bech32";
 static const std::string OUTPUT_TYPE_STRING_BECH32M = "bech32m";
+static const std::string OUTPUT_TYPE_STRING_BECH32_PQ = "bech32-pq";
 static const std::string OUTPUT_TYPE_STRING_UNKNOWN = "unknown";
 
 std::optional<OutputType> ParseOutputType(const std::string& type)
@@ -31,6 +32,8 @@ std::optional<OutputType> ParseOutputType(const std::string& type)
         return OutputType::BECH32;
     } else if (type == OUTPUT_TYPE_STRING_BECH32M) {
         return OutputType::BECH32M;
+    } else if (type == OUTPUT_TYPE_STRING_BECH32_PQ) {
+        return OutputType::BECH32_PQ;
     }
     return std::nullopt;
 }
@@ -42,6 +45,7 @@ const std::string& FormatOutputType(OutputType type)
     case OutputType::P2SH_SEGWIT: return OUTPUT_TYPE_STRING_P2SH_SEGWIT;
     case OutputType::BECH32: return OUTPUT_TYPE_STRING_BECH32;
     case OutputType::BECH32M: return OUTPUT_TYPE_STRING_BECH32M;
+    case OutputType::BECH32_PQ: return OUTPUT_TYPE_STRING_BECH32_PQ;
     case OutputType::UNKNOWN: return OUTPUT_TYPE_STRING_UNKNOWN;
     } // no default case, so the compiler can warn about missing cases
     assert(false);
@@ -63,7 +67,8 @@ CTxDestination GetDestinationForKey(const CPubKey& key, OutputType type)
         }
     }
     case OutputType::BECH32M:
-    case OutputType::UNKNOWN: {} // This function should never be used with BECH32M or UNKNOWN, so let it assert
+    case OutputType::BECH32_PQ:
+    case OutputType::UNKNOWN: {} // These types don't use CPubKey-based key generation
     } // no default case, so the compiler can warn about missing cases
     assert(false);
 }
@@ -102,7 +107,8 @@ CTxDestination AddAndGetDestinationForScript(FlatSigningProvider& keystore, cons
         }
     }
     case OutputType::BECH32M:
-    case OutputType::UNKNOWN: {} // This function should not be used for BECH32M or UNKNOWN, so let it assert
+    case OutputType::BECH32_PQ:
+    case OutputType::UNKNOWN: {} // These types don't use script-based destination generation
     } // no default case, so the compiler can warn about missing cases
     assert(false);
 }
@@ -119,6 +125,9 @@ std::optional<OutputType> OutputTypeFromDestination(const CTxDestination& dest) 
     if (std::holds_alternative<WitnessV1Taproot>(dest) ||
         std::holds_alternative<WitnessUnknown>(dest)) {
         return OutputType::BECH32M;
+    }
+    if (std::holds_alternative<WitnessV2PQ>(dest)) {
+        return OutputType::BECH32_PQ;
     }
     return std::nullopt;
 }

--- a/src/outputtype.h
+++ b/src/outputtype.h
@@ -19,6 +19,7 @@ enum class OutputType {
     P2SH_SEGWIT,
     BECH32,
     BECH32M,
+    BECH32_PQ,  //!< Post-quantum SPHINCS+ (witness v2, mars1z...)
     UNKNOWN,
 };
 
@@ -27,6 +28,7 @@ static constexpr auto OUTPUT_TYPES = std::array{
     OutputType::P2SH_SEGWIT,
     OutputType::BECH32,
     OutputType::BECH32M,
+    OutputType::BECH32_PQ,
 };
 
 std::optional<OutputType> ParseOutputType(const std::string& str);

--- a/src/wallet/rpc/addresses.cpp
+++ b/src/wallet/rpc/addresses.cpp
@@ -26,7 +26,7 @@ RPCHelpMan getnewaddress()
                 "so payments received with the address will be associated with 'label'.\n",
                 {
                     {"label", RPCArg::Type::STR, RPCArg::Default{""}, "The label name for the address to be linked to. It can also be set to the empty string \"\" to represent the default label. The label does not need to exist, it will be created if there is no label by the given name."},
-                    {"address_type", RPCArg::Type::STR, RPCArg::DefaultHint{"set by -addresstype"}, "The address type to use. Options are \"legacy\", \"p2sh-segwit\", \"bech32\", and \"bech32m\"."},
+                    {"address_type", RPCArg::Type::STR, RPCArg::DefaultHint{"set by -addresstype"}, "The address type to use. Options are \"legacy\", \"p2sh-segwit\", \"bech32\", and \"bech32m\". For post-quantum addresses use getnewpqaddress."},
                 },
                 RPCResult{
                     RPCResult::Type::STR, "address", "The new marscoin address"
@@ -56,6 +56,8 @@ RPCHelpMan getnewaddress()
             throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, strprintf("Unknown address type '%s'", request.params[1].get_str()));
         } else if (parsed.value() == OutputType::BECH32M && pwallet->GetLegacyScriptPubKeyMan()) {
             throw JSONRPCError(RPC_INVALID_PARAMETER, "Legacy wallets cannot provide bech32m addresses");
+        } else if (parsed.value() == OutputType::BECH32_PQ) {
+            throw JSONRPCError(RPC_INVALID_PARAMETER, "Use getnewpqaddress for post-quantum addresses");
         }
         output_type = parsed.value();
     }

--- a/src/wallet/rpc/wallet.cpp
+++ b/src/wallet/rpc/wallet.cpp
@@ -6,6 +6,8 @@
 #include <config/bitcoin-config.h> // IWYU pragma: keep
 
 #include <core_io.h>
+#include <crypto/pq_sphincs.h>
+#include <crypto/sha256.h>
 #include <key_io.h>
 #include <rpc/server.h>
 #include <rpc/util.h>
@@ -204,6 +206,85 @@ static RPCHelpMan getquantummigrationstatus()
     result.pushKV("migrated_balance", ValueFromAmount(0));
     result.pushKV("remaining_legacy_balance", ValueFromAmount(remaining_legacy));
     result.pushKV("recommended_next_action", "Review quantum-upgrade docs and wait for migration activation release");
+    return result;
+},
+    };
+}
+
+static RPCHelpMan getnewpqaddress()
+{
+    return RPCHelpMan{"getnewpqaddress",
+                "Generates a new SPHINCS+ post-quantum keypair and returns the corresponding\n"
+                "mars1z... (witness v2) address. The keypair is stored in the wallet.\n"
+                "Requires the OQS backend (--enable-pq-oqs-vendor at build time).\n",
+                {
+                    {"label", RPCArg::Type::STR, RPCArg::Default{""}, "An optional label for the address."},
+                },
+                RPCResult{
+                    RPCResult::Type::OBJ, "", "",
+                    {
+                        {RPCResult::Type::STR, "address", "the new mars1z... post-quantum address"},
+                        {RPCResult::Type::STR_HEX, "pubkey", "the SPHINCS+ public key (hex)"},
+                        {RPCResult::Type::STR, "parameter_set", "the SPHINCS+ parameter set name"},
+                        {RPCResult::Type::STR_HEX, "program", "the witness v2 program (SHA256 commitment)"},
+                    }
+                },
+                RPCExamples{
+                    HelpExampleCli("getnewpqaddress", "")
+            + HelpExampleCli("getnewpqaddress", "\"my-pq-label\"")
+            + HelpExampleRpc("getnewpqaddress", "")
+                },
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
+    std::shared_ptr<CWallet> const pwallet = GetWalletForJSONRPCRequest(request);
+    if (!pwallet) return UniValue::VNULL;
+
+    // Check OQS backend availability
+    std::string oqs_error;
+    if (!pq::sphincs::IsOQSBackendAvailable(pq::sphincs::ParameterSet::SLH_DSA_SHA2_128S, oqs_error)) {
+        throw JSONRPCError(RPC_MISC_ERROR, "SPHINCS+ OQS backend not available: " + oqs_error);
+    }
+
+    // Generate SPHINCS+ keypair
+    std::vector<unsigned char> pubkey;
+    std::vector<unsigned char> privkey;
+    std::string keygen_error;
+    if (!pq::sphincs::GenerateKeypair(pq::sphincs::ParameterSet::SLH_DSA_SHA2_128S, pubkey, privkey, keygen_error)) {
+        throw JSONRPCError(RPC_WALLET_ERROR, "Failed to generate SPHINCS+ keypair: " + keygen_error);
+    }
+
+    // Compute witness v2 program: SHA256(param_set_id || pubkey)
+    const uint8_t param_set_id = static_cast<uint8_t>(pq::sphincs::ParameterSet::SLH_DSA_SHA2_128S);
+    uint256 program;
+    CSHA256().Write(&param_set_id, 1)
+             .Write(pubkey.data(), pubkey.size())
+             .Finalize(program.begin());
+
+    // Create the destination and encode address
+    WitnessV2PQ pq_dest(program);
+    CTxDestination dest = pq_dest;
+    std::string address = EncodeDestination(dest);
+
+    // Store the PQ keypair in the wallet database
+    {
+        LOCK(pwallet->cs_wallet);
+
+        WalletBatch batch(pwallet->GetDatabase());
+        if (!batch.WritePQKey(program, param_set_id, pubkey, privkey)) {
+            throw JSONRPCError(RPC_WALLET_ERROR, "Failed to store SPHINCS+ key in wallet database");
+        }
+
+        // Add to address book with label
+        const std::string label{LabelFromValue(request.params[0])};
+        pwallet->SetAddressBook(dest, label, wallet::AddressPurpose::RECEIVE);
+    }
+
+    // Build response
+    UniValue result(UniValue::VOBJ);
+    result.pushKV("address", address);
+    result.pushKV("pubkey", HexStr(pubkey));
+    result.pushKV("parameter_set", pq::sphincs::ParameterSetName(pq::sphincs::ParameterSet::SLH_DSA_SHA2_128S));
+    result.pushKV("program", HexStr(program));
     return result;
 },
     };
@@ -1192,6 +1273,7 @@ Span<const CRPCCommand> GetWalletRPCCommands()
         {"wallet", &gettransaction},
         {"wallet", &getunconfirmedbalance},
         {"wallet", &getbalances},
+        {"wallet", &getnewpqaddress},
         {"wallet", &getquantummigrationstatus},
         {"wallet", &getwalletinfo},
         {"wallet", &importaddress},

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -303,6 +303,17 @@ bool WalletBatch::WriteDescriptorCacheItems(const uint256& desc_id, const Descri
     return true;
 }
 
+bool WalletBatch::WritePQKey(const uint256& program, uint8_t param_set_id,
+                            const std::vector<unsigned char>& pubkey,
+                            const std::vector<unsigned char>& privkey)
+{
+    std::vector<unsigned char> value;
+    value.push_back(param_set_id);
+    value.insert(value.end(), pubkey.begin(), pubkey.end());
+    value.insert(value.end(), privkey.begin(), privkey.end());
+    return WriteIC(std::make_pair(std::string("pqkey"), program), value);
+}
+
 bool WalletBatch::WriteLockedUTXO(const COutPoint& output)
 {
     return WriteIC(std::make_pair(DBKeys::LOCKED_UTXO, std::make_pair(output.hash, output.n)), uint8_t{'1'});

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -266,6 +266,12 @@ public:
     bool WriteDescriptorLastHardenedCache(const CExtPubKey& xpub, const uint256& desc_id, uint32_t key_exp_index);
     bool WriteDescriptorCacheItems(const uint256& desc_id, const DescriptorCache& cache);
 
+    //! Write a post-quantum SPHINCS+ keypair to the database.
+    //! Key: "pqkey" + program_hash, Value: param_set_id + pubkey + privkey
+    bool WritePQKey(const uint256& program, uint8_t param_set_id,
+                    const std::vector<unsigned char>& pubkey,
+                    const std::vector<unsigned char>& privkey);
+
     bool WriteLockedUTXO(const COutPoint& output);
     bool EraseLockedUTXO(const COutPoint& output);
 


### PR DESCRIPTION
## Summary

- New RPC `getnewpqaddress` generates SPHINCS+ keypairs and returns `mars1z...` addresses
- PQ keys stored in wallet DB via `WritePQKey` (param_set_id + pubkey + privkey)
- `OutputType::BECH32_PQ` added for post-quantum address type classification
- Existing `sendtoaddress` already works with `mars1z...` destinations (from PR #46)

**Depends on:** PR #46 (P2WPQH witness v2) — merged

**This enables the faucet use case:**
1. Pool mines coins on marsqnet
2. User calls `getnewpqaddress` → gets `mars1z...` address
3. Faucet calls `sendtoaddress mars1z... 1.0` → creates P2WPQH output
4. User receives quantum-resistant coins

**RPC example:**
```
$ marscoin-cli getnewpqaddress "my-pq-wallet"
{
  "address": "mars1z...",
  "pubkey": "8a69a3c0db2ef0d7...",
  "parameter_set": "SLH-DSA-SHA2-128s",
  "program": "a1b2c3d4..."
}
```

**Files changed (6):**
- `outputtype.h/cpp` — `BECH32_PQ` enum value + parsing/formatting
- `wallet/rpc/wallet.cpp` — `getnewpqaddress` RPC implementation
- `wallet/rpc/addresses.cpp` — reject `bech32-pq` in `getnewaddress` with guidance
- `wallet/walletdb.h/cpp` — `WritePQKey` database method

## Test plan

- [ ] `marscoind` builds cleanly (verified locally)
- [ ] `getnewpqaddress` returns valid `mars1z...` address (requires `--enable-pq-oqs-vendor`)
- [ ] `sendtoaddress <mars1z_addr> 1.0` creates valid P2WPQH output
- [ ] PQ key persists across wallet restart (DB round-trip)
- [ ] `getnewaddress "" "bech32-pq"` returns helpful error message

**Follow-up:** PQ transaction signing (spending from `mars1z...` addresses)

🤖 Generated with [Claude Code](https://claude.com/claude-code)