### PR TITLE
quantum: fix OQS backend activation, Qt linkage, and wallet creation

### DIFF
--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -340,7 +340,7 @@ marscoin_qt_libtoolflags = $(AM_LIBTOOLFLAGS) --tag CXX
 qt_marscoin_qt_CPPFLAGS = $(marscoin_qt_cppflags)
 qt_marscoin_qt_CXXFLAGS = $(marscoin_qt_cxxflags)
 qt_marscoin_qt_SOURCES = $(marscoin_qt_sources) init/bitcoin-qt.cpp
-qt_marscoin_qt_LDADD = $(marscoin_qt_ldadd) $(CRYPTO_LIBS)
+qt_marscoin_qt_LDADD = $(marscoin_qt_ldadd) $(CRYPTO_LIBS) $(OQS_VENDOR_LIBS)
 qt_marscoin_qt_LDFLAGS = $(marscoin_qt_ldflags)
 qt_marscoin_qt_LIBTOOLFLAGS = $(marscoin_qt_libtoolflags)
 

--- a/src/crypto/pq_sphincs.cpp
+++ b/src/crypto/pq_sphincs.cpp
@@ -2,6 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <config/bitcoin-config.h> // IWYU pragma: keep
+
 #include <crypto/pq_sphincs.h>
 
 #ifdef ENABLE_PQ_OQS_VENDOR

--- a/src/outputtype.h
+++ b/src/outputtype.h
@@ -28,8 +28,10 @@ static constexpr auto OUTPUT_TYPES = std::array{
     OutputType::P2SH_SEGWIT,
     OutputType::BECH32,
     OutputType::BECH32M,
-    OutputType::BECH32_PQ,
 };
+// BECH32_PQ is intentionally excluded from OUTPUT_TYPES because PQ keys
+// use a separate generation path (getnewpqaddress), not the standard
+// descriptor-based ScriptPubKeyMan system.
 
 std::optional<OutputType> ParseOutputType(const std::string& str);
 const std::string& FormatOutputType(OutputType type);


### PR DESCRIPTION
## Summary

Three critical fixes discovered during live testing of `getnewpqaddress`:

1. **pq_sphincs.cpp missing config include** — `ENABLE_PQ_OQS_VENDOR` was never defined at compile time because `config/bitcoin-config.h` wasn't included. The `#ifndef` stub path was always taken, making all OQS calls silently fail even with `--enable-pq-oqs-vendor`.

2. **Qt wallet missing liboqs linkage** — `$(OQS_VENDOR_LIBS)` was added to `marscoind` but not `marscoin-qt`. The GUI wallet couldn't use the OQS backend.

3. **Wallet creation crash** — `BECH32_PQ` in `OUTPUT_TYPES` caused `SetupDescriptorScriptPubKeyMans` to crash trying to create a descriptor for PQ output type. PQ uses its own key generation path (`getnewpqaddress`), not the descriptor system.

**All nodes need these fixes** for `getnewpqaddress` to work. Without fix #1, the RPC returns "OQS backend not enabled" even on correctly configured builds.

## Test plan

- [x] `getnewpqaddress` returns valid `mars1z...` address (verified on macOS Qt wallet)
- [x] Wallet creation succeeds without crash
- [x] Qt wallet links OQS and produces real SPHINCS+ keys

🤖 Generated with [Claude Code](https://claude.com/claude-code)