### PR TITLE
quantum: make SCRIPT_VERIFY_WITNESS_V2 a mandatory verify flag

### DIFF
--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -92,7 +92,8 @@ static constexpr unsigned int MANDATORY_SCRIPT_VERIFY_FLAGS{SCRIPT_VERIFY_P2SH |
                                                              SCRIPT_VERIFY_CHECKLOCKTIMEVERIFY |
                                                              SCRIPT_VERIFY_CHECKSEQUENCEVERIFY |
                                                              SCRIPT_VERIFY_WITNESS |
-                                                             SCRIPT_VERIFY_TAPROOT};
+                                                             SCRIPT_VERIFY_TAPROOT |
+                                                             SCRIPT_VERIFY_WITNESS_V2};
 
 /**
  * Standard script verification flags that standard transactions will comply


### PR DESCRIPTION
## Critical fix

Nodes were rejecting blocks containing PQ transactions and marking them permanently invalid, preventing chain sync. Root cause: `SCRIPT_VERIFY_WITNESS_V2` was a non-mandatory flag, causing a pass/fail mismatch during block validation retry that triggered the "BUG!" assertion.

Fix: add `SCRIPT_VERIFY_WITNESS_V2` to `MANDATORY_SCRIPT_VERIFY_FLAGS`, matching `SCRIPT_VERIFY_WITNESS` and `SCRIPT_VERIFY_TAPROOT`.

**Impact:** All marsqnet nodes must rebuild with this fix. Nodes stuck at block 1382 need `reconsiderblock` + restart after update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)